### PR TITLE
Fix code formatter issue in SparseBitVector.h

### DIFF
--- a/llvm/include/llvm/ADT/SparseBitVector.h
+++ b/llvm/include/llvm/ADT/SparseBitVector.h
@@ -152,8 +152,8 @@ public:
     unsigned WordPos = Curr / BITWORD_SIZE;
     unsigned BitPos = Curr % BITWORD_SIZE;
     BitWord Copy = Bits[WordPos];
-    assert(WordPos <= BITWORDS_PER_ELEMENT
-           && "Word Position outside of element");
+    assert(WordPos < BITWORDS_PER_ELEMENT &&
+           "Word Position outside of element");
 
     // Mask off previous bits.
     Copy &= ~0UL << BitPos;


### PR DESCRIPTION
This PR fixes the code formatter issue by properly formatting the assert statement in SparseBitVector.h. The change also updates the assertion to use `<` instead of `<=` as requested in the original PR.